### PR TITLE
fix: docker package name

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }} # works if org allows Actions to publish packages
 
       - name: Set IMAGE env
-        run: echo "IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/yaci" >> "$GITHUB_ENV"
+        run: echo "IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/manifest-app" >> "$GITHUB_ENV"
 
       - name: Create .env file
         run: |


### PR DESCRIPTION
This pull request makes a minor update to the Docker workflow configuration by changing the image name used in the environment variable from `yaci` to `manifest-app`. This ensures that the correct Docker image is referenced during the build and deployment process.