### PR TITLE
fix: build essentials for bigint bindings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-RUN apt update && apt install -y git
+RUN apt update && apt install -y --no-install-recommends git build-essential python3
 
 RUN \
     if [ -f .env ]; then echo ".env file found, continuing..."; else echo ".env file not found, exiting..."; exit 1; fi


### PR DESCRIPTION
This pull request updates the dependencies installed in the Docker image to ensure all necessary build tools and Python are available, while keeping the image lean by avoiding unnecessary packages.

Dependency installation improvements:

* Modified the Dockerfile to install `git`, `build-essential`, and `python3` using `apt` with the `--no-install-recommends` flag, which reduces image size by excluding optional packages.