### PR TITLE
fix: build env before install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ FROM oven/bun:1.2-slim AS base
 FROM base AS deps
 WORKDIR /app
 
+RUN apt update && apt install -y --no-install-recommends build-essential python3
+
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* bun.lock* ./
 RUN \
@@ -23,7 +25,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-RUN apt update && apt install -y --no-install-recommends git build-essential python3
+RUN apt update && apt install -y git
 
 RUN \
     if [ -f .env ]; then echo ".env file found, continuing..."; else echo ".env file not found, exiting..."; exit 1; fi


### PR DESCRIPTION
This pull request updates the `Dockerfile` to optimize the installation of build tools and dependencies. The main changes involve splitting the installation of `build-essential` and `python3` into the `deps` stage, and reducing the installed packages in the final build stage to only `git`.

Dependency installation optimization:

* Moved installation of `build-essential` and `python3` to the `deps` stage to ensure they are only present where needed for building dependencies, reducing the final image size.
* Reduced the final build stage to only install `git`, removing unnecessary build tools from the production image.