### PR TITLE
fix: metadata pagination in token factory page

### DIFF
--- a/hooks/useQueries.ts
+++ b/hooks/useQueries.ts
@@ -624,18 +624,43 @@ export const useDenomAuthorityMetadata = (denom: string) => {
 export const useTokenFactoryDenomsMetadata = () => {
   const { lcdQueryClient } = useLcdQueryClient();
 
-  const fetchDenoms = async () => {
+  const fetchAllDenoms = async () => {
     if (!lcdQueryClient) {
       throw new Error('LCD Client not ready');
     }
 
-    return await lcdQueryClient.cosmos.bank.v1beta1.denomsMetadata({});
+    let allMetadatas: any[] = [];
+    let nextKey: Uint8Array | undefined = undefined;
+
+    // Fetch all pages of metadata
+    do {
+      const paginationOptions: any = {
+        limit: BigInt(1000), // Request more per page to reduce API calls
+      };
+      
+      if (nextKey) {
+        paginationOptions.key = nextKey;
+      }
+
+      const response = await lcdQueryClient.cosmos.bank.v1beta1.denomsMetadata({
+        pagination: paginationOptions,
+      });
+
+      if (response.metadatas) {
+        allMetadatas = allMetadatas.concat(response.metadatas);
+      }
+
+      nextKey = response.pagination?.next_key;
+    } while (nextKey && nextKey.length > 0);
+
+    return { metadatas: allMetadatas };
   };
 
   const denomsQuery = useQuery({
     queryKey: ['allMetadatas'],
-    queryFn: fetchDenoms,
+    queryFn: fetchAllDenoms,
     enabled: !!lcdQueryClient,
+    staleTime: 5 * 60 * 1000, // Cache for 5 minutes since metadata doesn't change often
   });
 
   return {
@@ -643,6 +668,37 @@ export const useTokenFactoryDenomsMetadata = () => {
     isMetadatasLoading: denomsQuery.isLoading,
     isMetadatasError: denomsQuery.isError,
     refetchMetadatas: denomsQuery.refetch,
+  };
+};
+
+export const useDenomMetadata = (denom: string) => {
+  const { lcdQueryClient } = useLcdQueryClient();
+
+  const fetchDenomMetadata = async () => {
+    if (!lcdQueryClient) {
+      throw new Error('LCD Client not ready');
+    }
+    if (!denom) {
+      return null;
+    }
+
+    return await lcdQueryClient.cosmos.bank.v1beta1.denomMetadata({ denom });
+  };
+
+  const debounced = useDebounce(denom, DEBOUNCE_TIME);
+  const metadataQuery = useQuery({
+    queryKey: ['denomMetadata', debounced],
+    queryFn: fetchDenomMetadata,
+    enabled: !!lcdQueryClient && !!denom,
+    staleTime: DEBOUNCE_TIME,
+    placeholderData: keepPreviousData,
+  });
+
+  return {
+    metadata: metadataQuery.data?.metadata,
+    isMetadataLoading: metadataQuery.isLoading,
+    isMetadataError: metadataQuery.isError,
+    refetchMetadata: metadataQuery.refetch,
   };
 };
 

--- a/hooks/useQueries.ts
+++ b/hooks/useQueries.ts
@@ -637,7 +637,7 @@ export const useTokenFactoryDenomsMetadata = () => {
       const paginationOptions: any = {
         limit: BigInt(1000), // Request more per page to reduce API calls
       };
-      
+
       if (nextKey) {
         paginationOptions.key = nextKey;
       }


### PR DESCRIPTION
This PR fixes an issue where token factory metadata paginated responses stop some users tokens from loading in the token factory page
