### PR TITLE
ci: diff release branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
       - release/testnet
       - release/mainnet
     tags:
-      - 'v*.*.*'   # versioned release tags for mainnet
+      - 'v*.*.*' # versioned release tags for mainnet
 
 concurrency:
   group: docker-${{ github.ref }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker (GHCR)
 on:
   push:
     branches:
+      - release/qa
       - release/testnet
       - release/mainnet
     tags:
@@ -21,6 +22,9 @@ jobs:
     strategy:
       matrix:
         include:
+          - branch: refs/heads/release/qa
+            environment: qa
+            env_tag: qa
           - branch: refs/heads/release/testnet
             environment: testnet
             env_tag: testnet

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,10 @@ name: Docker (GHCR)
 on:
   push:
     branches:
-      - main
+      - release/testnet
+      - release/mainnet
     tags:
-      - '*'
+      - 'v*.*.*'   # versioned release tags for mainnet
 
 concurrency:
   group: docker-${{ github.ref }}
@@ -17,16 +18,31 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [qa, testnet, mainnet]
+        include:
+          - branch: refs/heads/release/testnet
+            environment: testnet
+            env_tag: testnet
+          - branch: refs/heads/release/mainnet
+            environment: mainnet
+            env_tag: mainnet
+
+    # Run row if:
+    #  - this is a branch push AND it matches the row's branch, OR
+    #  - this is a tag push AND the row is mainnet.
+    if: >
+      (startsWith(github.ref, 'refs/heads/') && github.ref == matrix.branch) ||
+      (startsWith(github.ref, 'refs/tags/') && matrix.environment == 'mainnet')
+
+    runs-on: ubuntu-latest
     environment: ${{ matrix.environment }}
     permissions:
       packages: write
       contents: read
       attestations: write
       id-token: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,7 +55,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }} # works if org allows Actions to publish packages
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set IMAGE env
         run: echo "IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/manifest-app" >> "$GITHUB_ENV"
@@ -67,20 +83,21 @@ jobs:
           echo "NEXT_PUBLIC_MFX_TO_PWR_CONVERSION_CONTRACT_ADDRESS=${{ vars.NEXT_PUBLIC_MFX_TO_PWR_CONVERSION_CONTRACT_ADDRESS }}" >> .env
           cat .env
 
+      # ===== Release build (version tag) — mainnet only =====
       - name: Extract metadata (release tag)
         id: meta_tag
-        if: matrix.environment == 'mainnet' && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.environment == 'mainnet'
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE }}
           flavor: |
             latest=false
           tags: |
-            type=ref,event=tag   # yields the raw tag (e.g., v1.2.3)
+            type=ref,event=tag   # e.g., v1.2.3
 
       - name: Build & push (release tag)
         id: build_tag
-        if: matrix.environment == 'mainnet' && startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.environment == 'mainnet'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -105,21 +122,21 @@ jobs:
           subject-digest: ${{ steps.build_tag.outputs.digest }}
           push-to-registry: true
 
-      # ===== Push to main → build for each env, tag with env name =====
+      # ===== Branch build (release/*) — env tag =====
       - name: Extract metadata (env tag)
         id: meta_env
-        if: github.ref == 'refs/heads/main'
+        if: startsWith(github.ref, 'refs/heads/')
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE }}
           flavor: |
             latest=false
           tags: |
-            type=raw,value=${{ matrix.environment }}
+            type=raw,value=${{ matrix.env_tag }}
 
       - name: Build & push (env tag)
         id: build_env
-        if: github.ref == 'refs/heads/main'
+        if: startsWith(github.ref, 'refs/heads/')
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
This pull request updates the Docker GitHub Actions workflow to support separate release branches for `testnet` and `mainnet`, and refines how Docker images are built and tagged for both branch and tag-based releases. The workflow now ensures that only the appropriate environments are built for each branch or tag push, and improves tagging and metadata extraction for Docker images.

**Branch and environment handling:**

* The workflow now triggers on pushes to `release/testnet` and `release/mainnet` branches, as well as versioned tags (`v*.*.*`), instead of just `main` and any tag.
* The build matrix is replaced with explicit branch/environment mapping, ensuring that only the relevant environment is built for each branch or tag. Conditional logic ensures that branch builds only run for their corresponding environment, and tag builds only run for `mainnet`.

**Docker image tagging and metadata extraction:**

* Docker image tags for branch builds now use the `env_tag` field, providing clearer environment-specific tags. Tag builds continue to use the raw version tag.
* Metadata extraction and build steps for both tag and branch builds are now gated by improved conditional checks, ensuring correct behavior for each release type. [[1]](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94R86-R100) [[2]](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L108-R139)

**Minor improvements:**

* Minor cleanup in Docker login and comment formatting for clarity.