### PR TITLE
ci: reusable docker build

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -67,7 +67,6 @@ jobs:
           echo "NEXT_PUBLIC_UPGRADE_MIN_BLOCK_OFFSET=${{ vars.NEXT_PUBLIC_UPGRADE_MIN_BLOCK_OFFSET }}" >> .env
           echo "NEXT_PUBLIC_MFX_TO_PWR_CONVERSION_CONTRACT_ADDRESS=${{ vars.NEXT_PUBLIC_MFX_TO_PWR_CONVERSION_CONTRACT_ADDRESS }}" >> .env
 
-      # Release tag path (mainnet)
       - name: Extract metadata (release tag)
         id: meta_tag
         if: inputs.release_tag != ''
@@ -93,7 +92,6 @@ jobs:
           provenance: mode=max
           sbom: true
 
-      # Branch env path (qa/testnet/mainnet)
       - name: Extract metadata (env tag)
         id: meta_env
         if: inputs.release_tag == ''

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -3,16 +3,16 @@ name: _docker-build
 on:
   workflow_call:
     inputs:
-      environment:         # qa | testnet | mainnet
+      environment: # qa | testnet | mainnet
         type: string
         required: true
-      image_tag:           # "qa" | "testnet" | "mainnet" | ignored if release_tag set
+      image_tag: # "qa" | "testnet" | "mainnet" | ignored if release_tag set
         type: string
         required: true
-      release_tag:         # e.g. v1.2.3 (optional). If set, we build a release image.
+      release_tag: # e.g. v1.2.3 (optional). If set, we build a release image.
         type: string
         required: false
-        default: ""
+        default: ''
 
 jobs:
   build:

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -1,0 +1,129 @@
+name: _docker-build
+
+on:
+  workflow_call:
+    inputs:
+      environment:         # qa | testnet | mainnet
+        type: string
+        required: true
+      image_tag:           # "qa" | "testnet" | "mainnet" | ignored if release_tag set
+        type: string
+        required: true
+      release_tag:         # e.g. v1.2.3 (optional). If set, we build a release image.
+        type: string
+        required: false
+        default: ""
+    secrets:
+      inherit: true        # pass caller secrets/env-secrets through
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set IMAGE env
+        run: echo "IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/manifest-app" >> "$GITHUB_ENV"
+
+      - name: Create .env from environment vars/secrets
+        run: |
+          touch .env
+          echo "NEXT_PUBLIC_CHAIN=${{ vars.NEXT_PUBLIC_CHAIN }}" >> .env
+          echo "NEXT_PUBLIC_CHAIN_ID=${{ vars.NEXT_PUBLIC_CHAIN_ID }}" >> .env
+          echo "NEXT_PUBLIC_CHAIN_TIER=${{ vars.NEXT_PUBLIC_CHAIN_TIER }}" >> .env
+          echo "NEXT_PUBLIC_RPC_URL=${{ vars.NEXT_PUBLIC_RPC_URL }}" >> .env
+          echo "NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL }}" >> .env
+          echo "NEXT_PUBLIC_WALLETCONNECT_KEY=${{ secrets.NEXT_PUBLIC_WALLETCONNECT_KEY }}" >> .env
+          echo "NEXT_PUBLIC_WEB3AUTH_NETWORK=${{ vars.NEXT_PUBLIC_WEB3AUTH_NETWORK }}" >> .env
+          echo "NEXT_PUBLIC_WEB3AUTH_CLIENT_ID=${{ secrets.NEXT_PUBLIC_WEB3AUTH_CLIENT_ID }}" >> .env
+          echo "NEXT_PUBLIC_EXPLORER_URL=${{ vars.NEXT_PUBLIC_EXPLORER_URL }}" >> .env
+          echo "NEXT_PUBLIC_INDEXER_URL=${{ vars.NEXT_PUBLIC_INDEXER_URL }}" >> .env
+          echo "NEXT_PUBLIC_OSMOSIS_CHAIN=${{ vars.NEXT_PUBLIC_OSMOSIS_CHAIN }}" >> .env
+          echo "NEXT_PUBLIC_OSMOSIS_CHAIN_ID=${{ vars.NEXT_PUBLIC_OSMOSIS_CHAIN_ID }}" >> .env
+          echo "NEXT_PUBLIC_OSMOSIS_RPC_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_RPC_URL }}" >> .env
+          echo "NEXT_PUBLIC_OSMOSIS_API_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_API_URL }}" >> .env
+          echo "NEXT_PUBLIC_OSMOSIS_EXPLORER_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_EXPLORER_URL }}" >> .env
+          echo "NEXT_PUBLIC_LEAP_DEEPLINK=${{ vars.NEXT_PUBLIC_LEAP_DEEPLINK }}" >> .env
+          echo "NEXT_PUBLIC_UPGRADE_MIN_BLOCK_OFFSET=${{ vars.NEXT_PUBLIC_UPGRADE_MIN_BLOCK_OFFSET }}" >> .env
+          echo "NEXT_PUBLIC_MFX_TO_PWR_CONVERSION_CONTRACT_ADDRESS=${{ vars.NEXT_PUBLIC_MFX_TO_PWR_CONVERSION_CONTRACT_ADDRESS }}" >> .env
+
+      # Release tag path (mainnet)
+      - name: Extract metadata (release tag)
+        id: meta_tag
+        if: inputs.release_tag != ''
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ inputs.release_tag }}
+
+      - name: Build & push (release tag)
+        id: build_tag
+        if: inputs.release_tag != ''
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta_tag.outputs.tags }}
+          labels: ${{ steps.meta_tag.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      # Branch env path (qa/testnet/mainnet)
+      - name: Extract metadata (env tag)
+        id: meta_env
+        if: inputs.release_tag == ''
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ inputs.image_tag }}
+
+      - name: Build & push (env tag)
+        id: build_env
+        if: inputs.release_tag == ''
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta_env.outputs.tags }}
+          labels: ${{ steps.meta_env.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Generate artifact attestation
+        if: (inputs.release_tag != '' && steps.build_tag.outcome == 'success') || (inputs.release_tag == '' && steps.build_env.outcome == 'success')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ inputs.release_tag != '' && steps.build_tag.outputs.digest || steps.build_env.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -13,8 +13,6 @@ on:
         type: string
         required: false
         default: ""
-    secrets:
-      inherit: true        # pass caller secrets/env-secrets through
 
 jobs:
   build:
@@ -120,10 +118,18 @@ jobs:
           provenance: mode=max
           sbom: true
 
-      - name: Generate artifact attestation
-        if: (inputs.release_tag != '' && steps.build_tag.outcome == 'success') || (inputs.release_tag == '' && steps.build_env.outcome == 'success')
+      - name: Generate artifact attestation (release tag)
+        if: inputs.release_tag != '' && steps.build_tag.outcome == 'success'
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.IMAGE }}
-          subject-digest: ${{ inputs.release_tag != '' && steps.build_tag.outputs.digest || steps.build_env.outputs.digest }}
+          subject-digest: ${{ steps.build_tag.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation (env tag)
+        if: inputs.release_tag == '' && steps.build_env.outcome == 'success'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build_env.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -14,6 +14,10 @@ on:
         required: false
         default: ''
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -27,9 +27,6 @@ jobs:
       contents: read
       attestations: write
       id-token: write
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
       - release/testnet
       - release/mainnet
     tags:
-      - 'v*.*.*'   # release tags
+      - 'v*.*.*' # release tags
 
 concurrency:
   group: docker-${{ github.ref }}
@@ -44,5 +44,5 @@ jobs:
     with:
       environment: mainnet
       image_tag: mainnet
-      release_tag: ${{ github.ref_name }}   # e.g., v1.2.3
+      release_tag: ${{ github.ref_name }} # e.g., v1.2.3
     secrets: inherit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,154 +7,42 @@ on:
       - release/testnet
       - release/mainnet
     tags:
-      - 'v*.*.*' # versioned release tags for mainnet
+      - 'v*.*.*'   # release tags
 
 concurrency:
   group: docker-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
-  build-and-push:
-    if: ${{ github.ref == matrix.branch || (startsWith(github.ref, 'refs/tags/') && matrix.environment == 'mainnet') }}
-    strategy:
-      matrix:
-        include:
-          - branch: refs/heads/release/qa
-            environment: qa
-            env_tag: qa
-          - branch: refs/heads/release/testnet
-            environment: testnet
-            env_tag: testnet
-          - branch: refs/heads/release/mainnet
-            environment: mainnet
-            env_tag: mainnet
+  qa:
+    if: github.ref == 'refs/heads/release/qa'
+    uses: ./.github/workflows/_docker-build.yml
+    with:
+      environment: qa
+      image_tag: qa
+    secrets: inherit
 
-    runs-on: ubuntu-latest
-    environment: ${{ matrix.environment }}
-    permissions:
-      packages: write
-      contents: read
-      attestations: write
-      id-token: write
+  testnet:
+    if: github.ref == 'refs/heads/release/testnet'
+    uses: ./.github/workflows/_docker-build.yml
+    with:
+      environment: testnet
+      image_tag: testnet
+    secrets: inherit
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  mainnet:
+    if: github.ref == 'refs/heads/release/mainnet'
+    uses: ./.github/workflows/_docker-build.yml
+    with:
+      environment: mainnet
+      image_tag: mainnet
+    secrets: inherit
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set IMAGE env
-        run: echo "IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/manifest-app" >> "$GITHUB_ENV"
-
-      - name: Create .env file
-        run: |
-          touch .env
-          echo "NEXT_PUBLIC_CHAIN=${{ vars.NEXT_PUBLIC_CHAIN }}" >> .env
-          echo "NEXT_PUBLIC_CHAIN_ID=${{ vars.NEXT_PUBLIC_CHAIN_ID }}" >> .env
-          echo "NEXT_PUBLIC_CHAIN_TIER=${{ vars.NEXT_PUBLIC_CHAIN_TIER }}" >> .env
-          echo "NEXT_PUBLIC_RPC_URL=${{ vars.NEXT_PUBLIC_RPC_URL }}" >> .env
-          echo "NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL }}" >> .env
-          echo "NEXT_PUBLIC_WALLETCONNECT_KEY=${{ secrets.NEXT_PUBLIC_WALLETCONNECT_KEY }}" >> .env
-          echo "NEXT_PUBLIC_WEB3AUTH_NETWORK=${{ vars.NEXT_PUBLIC_WEB3AUTH_NETWORK }}" >> .env
-          echo "NEXT_PUBLIC_WEB3AUTH_CLIENT_ID=${{ secrets.NEXT_PUBLIC_WEB3AUTH_CLIENT_ID }}" >> .env
-          echo "NEXT_PUBLIC_EXPLORER_URL=${{ vars.NEXT_PUBLIC_EXPLORER_URL }}" >> .env
-          echo "NEXT_PUBLIC_INDEXER_URL=${{ vars.NEXT_PUBLIC_INDEXER_URL }}" >> .env
-          echo "NEXT_PUBLIC_OSMOSIS_CHAIN=${{ vars.NEXT_PUBLIC_OSMOSIS_CHAIN }}" >> .env
-          echo "NEXT_PUBLIC_OSMOSIS_CHAIN_ID=${{ vars.NEXT_PUBLIC_OSMOSIS_CHAIN_ID }}" >> .env
-          echo "NEXT_PUBLIC_OSMOSIS_RPC_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_RPC_URL }}" >> .env
-          echo "NEXT_PUBLIC_OSMOSIS_API_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_API_URL }}" >> .env
-          echo "NEXT_PUBLIC_OSMOSIS_EXPLORER_URL=${{ vars.NEXT_PUBLIC_OSMOSIS_EXPLORER_URL }}" >> .env
-          echo "NEXT_PUBLIC_LEAP_DEEPLINK=${{ vars.NEXT_PUBLIC_LEAP_DEEPLINK }}" >> .env
-          echo "NEXT_PUBLIC_UPGRADE_MIN_BLOCK_OFFSET=${{ vars.NEXT_PUBLIC_UPGRADE_MIN_BLOCK_OFFSET }}" >> .env
-          echo "NEXT_PUBLIC_MFX_TO_PWR_CONVERSION_CONTRACT_ADDRESS=${{ vars.NEXT_PUBLIC_MFX_TO_PWR_CONVERSION_CONTRACT_ADDRESS }}" >> .env
-          cat .env
-
-      # ===== Release build (version tag) — mainnet only =====
-      - name: Extract metadata (release tag)
-        id: meta_tag
-        if: startsWith(github.ref, 'refs/tags/') && matrix.environment == 'mainnet'
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE }}
-          flavor: |
-            latest=false
-          tags: |
-            type=ref,event=tag   # e.g., v1.2.3
-
-      - name: Build & push (release tag)
-        id: build_tag
-        if: startsWith(github.ref, 'refs/tags/') && matrix.environment == 'mainnet'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta_tag.outputs.tags }}
-          labels: ${{ steps.meta_tag.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: mode=max
-          sbom: true
-
-      - name: Show digest (release)
-        if: steps.build_tag.outcome == 'success'
-        run: |
-          echo "Digest is: ${{ steps.build_tag.outputs.digest }}"
-
-      - name: Generate artifact attestation (release)
-        if: steps.build_tag.outcome == 'success'
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.IMAGE }}
-          subject-digest: ${{ steps.build_tag.outputs.digest }}
-          push-to-registry: true
-
-      # ===== Branch build (release/*) — env tag =====
-      - name: Extract metadata (env tag)
-        id: meta_env
-        if: startsWith(github.ref, 'refs/heads/')
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE }}
-          flavor: |
-            latest=false
-          tags: |
-            type=raw,value=${{ matrix.env_tag }}
-
-      - name: Build & push (env tag)
-        id: build_env
-        if: startsWith(github.ref, 'refs/heads/')
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta_env.outputs.tags }}
-          labels: ${{ steps.meta_env.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: mode=max
-          sbom: true
-
-      - name: Show digest (env)
-        if: steps.build_env.outcome == 'success'
-        run: |
-          echo "Digest is: ${{ steps.build_env.outputs.digest }}"
-
-      - name: Generate artifact attestation (env)
-        if: steps.build_env.outcome == 'success'
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.IMAGE }}
-          subject-digest: ${{ steps.build_env.outputs.digest }}
-          push-to-registry: true
+  release_tag:
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/_docker-build.yml
+    with:
+      environment: mainnet
+      image_tag: mainnet
+      release_tag: ${{ github.ref_name }}   # e.g., v1.2.3
+    secrets: inherit


### PR DESCRIPTION
This pull request refactors the Docker build workflow to use a centralized, reusable workflow file for all build environments (qa, testnet, mainnet, and release tags). The main goals are to reduce duplication, simplify maintenance, and ensure consistent build logic across environments.

Workflow refactoring and centralization:

* Introduced a new reusable workflow file `_docker-build.yml` that encapsulates all Docker build and push logic, including environment setup, metadata extraction, image building, and attestation generation. (.github/workflows/_docker-build.yml)
* Updated the main `docker.yml` workflow to delegate environment-specific jobs (`qa`, `testnet`, `mainnet`, and `release_tag`) to the new reusable workflow, passing the relevant parameters and secrets. This removes duplicated steps and matrix logic. (.github/workflows/docker.yml)

Build configuration and secrets handling:

* Standardized environment variable and secret injection for all build jobs, ensuring consistent `.env` file generation and secure handling of sensitive values. (.github/workflows/_docker-build.yml)
* Improved tagging logic for release builds by explicitly passing the release tag as an input to the reusable workflow, supporting both branch and versioned release builds. (.github/workflows/_docker-build.yml, .github/workflows/docker.yml) [[1]](diffhunk://#diff-4945b2f828e1af202ba62a55c62194987439acf13073cc728f97b8ab4fd29833R1-R129) [[2]](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L10-R48)

Artifact attestation and provenance:

* Ensured artifact attestation and provenance generation are performed for both release and environment builds, with outcome-based conditional execution. (.github/workflows/_docker-build.yml)