### PR TITLE
ci: fix docker permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,12 @@ concurrency:
   group: docker-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
 jobs:
   qa:
     if: github.ref == 'refs/heads/release/qa'


### PR DESCRIPTION
This pull request adds explicit permissions to the GitHub Actions workflow configuration in `.github/workflows/docker.yml` to improve security and enable required actions for package publishing and attestations.

Workflow permissions update:

* Added `permissions` section granting read access to `contents`, write access to `packages`, and write access to `id-token` and `attestations` in `.github/workflows/docker.yml`.