### PR TITLE
feat: msg community pool spend handler

### DIFF
--- a/components/bank/handlers/distribution/index.ts
+++ b/components/bank/handlers/distribution/index.ts
@@ -1,0 +1,1 @@
+export * from './msgCommunityPoolSpendHandler';

--- a/components/bank/handlers/distribution/msgCommunityPoolSpendHandler.tsx
+++ b/components/bank/handlers/distribution/msgCommunityPoolSpendHandler.tsx
@@ -1,0 +1,40 @@
+import { MsgCommunityPoolSpend } from '@manifest-network/manifestjs/dist/codegen/cosmos/distribution/v1beta1/tx';
+
+import { createTokenMessage } from '@/components';
+import { registerHandler } from '@/components/bank/handlers/handlerRegistry';
+import { BankIcon } from '@/components/icons/BankIcon';
+
+import { createSenderReceiverHandler } from '../createSenderReceiverHandler';
+
+export const MsgCommunityPoolSpendHandler = createSenderReceiverHandler({
+  iconSender: BankIcon,
+  successSender: (tx, _, metadata) => {
+    return createTokenMessage(
+      'You sent {0} from the community pool to {1}',
+      tx.metadata?.amount,
+      tx.metadata?.recipient,
+      'yellow',
+      metadata
+    );
+  },
+  failSender: (tx, _, metadata) => {
+    return createTokenMessage(
+      'You failed to send {0} from the community pool to {1}',
+      tx.metadata?.amount,
+      tx.metadata?.recipient,
+      'red',
+      metadata
+    );
+  },
+  successReceiver: (tx, _, metadata) => {
+    return createTokenMessage(
+      'You received {0} from the community pool',
+      tx.metadata?.amount,
+      tx.sender,
+      'green',
+      metadata
+    );
+  },
+});
+
+registerHandler(MsgCommunityPoolSpend.typeUrl, MsgCommunityPoolSpendHandler);

--- a/components/bank/handlers/index.ts
+++ b/components/bank/handlers/index.ts
@@ -1,4 +1,5 @@
 export * from './bank';
+export * from './distribution';
 export * from './feegrant';
 export * from './ibc';
 export * from './tokenfactory';


### PR DESCRIPTION
This pull request adds support for handling the `MsgCommunityPoolSpend` transaction type in the bank distribution handlers. The main changes involve registering a new handler and updating exports to make the handler available throughout the app.

**Distribution Handler Additions:**

* Added and exported the `MsgCommunityPoolSpendHandler` in `components/bank/handlers/distribution/msgCommunityPoolSpendHandler.tsx`, which provides sender and receiver messages for successful and failed community pool spend transactions.
* Registered the new handler using the `registerHandler` function for the `MsgCommunityPoolSpend.typeUrl`.

**Exports and Integration:**

* Updated `components/bank/handlers/distribution/index.ts` to export the new handler.
* Updated `components/bank/handlers/index.ts` to export everything from the `distribution` handlers, making the new handler available for import elsewhere.

<img width="1510" height="930" alt="2025-09-25_11-13" src="https://github.com/user-attachments/assets/f4ba1c9c-e8b7-4cba-a4e8-7255a3f8eff9" />
